### PR TITLE
Update igrowl.js

### DIFF
--- a/dist/js/igrowl.js
+++ b/dist/js/igrowl.js
@@ -37,7 +37,7 @@
 
 
 		// image / icon
-		if ( options.image.src ) {
+		if ( options.image && options.image.src ) {
 			template.prepend('<div class="igrowl-img '+ options.image.class +'"><img src="'+ options.image.src +'"</div>');
 		} else if (options.icon) {
 			template.prepend('<div class="igrowl-icon i-'+ options.icon + '"></div>');


### PR DESCRIPTION
without checking if options.image, validating options.image.src causes js errors in old browsers and chrome.